### PR TITLE
fix mimepull memery leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jvnet.mimepull</groupId>
     <artifactId>mimepull</artifactId>
-    <version>1.9.8-SNAPSHOT</version>
+    <version>1.9.8</version>
     <packaging>jar</packaging>
 
     <name>MIME streaming extension</name>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.jvnet.mimepull</groupId>
     <artifactId>mimepull</artifactId>
-    <version>1.9.8</version>
+    <version>1.9.8-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>MIME streaming extension</name>

--- a/src/main/java/org/jvnet/mimepull/MemoryData.java
+++ b/src/main/java/org/jvnet/mimepull/MemoryData.java
@@ -95,7 +95,8 @@ final class MemoryData implements Data {
                 String suffix = config.getTempFileSuffix();
                 File tempFile = TempFiles.createTempFile(prefix, suffix, config.getTempDir());
                 // delete the temp file when VM exits as a last resort for file clean up
-                tempFile.deleteOnExit();
+                // deleteOnExit can be casue memory leak, (for vast file references stored in DeleteOnExitHook.files)
+                //tempFile.deleteOnExit();
                 if (LOGGER.isLoggable(Level.FINE)) {
                     LOGGER.log(Level.FINE, "Created temp file = {0}", tempFile);
                 }


### PR DESCRIPTION
//deleteOnExit can be casue memory leak, (for vast file references stored in DeleteOnExitHook.files)
tempFile.deleteOnExit();